### PR TITLE
Allows use of symbolic tensors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensors"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -25,10 +25,10 @@ export tovoigt, tovoigt!, fromvoigt, tomandel, tomandel!, frommandel
 #########
 # Types #
 #########
-abstract type AbstractTensor{order, dim, T <: Real} <: AbstractArray{T, order} end
+abstract type AbstractTensor{order, dim, T <: Number} <: AbstractArray{T, order} end
 
 """
-    SymmetricTensor{order,dim,T<:Real}
+    SymmetricTensor{order,dim,T<:Number}
 
 Symmetric tensor type supported for `order ∈ (2,4)` and `dim ∈ (1,2,3)`.
 `SymmetricTensor{4}` is a minor symmetric tensor, such that
@@ -48,7 +48,7 @@ struct SymmetricTensor{order, dim, T, M} <: AbstractTensor{order, dim, T}
 end
 
 """
-    Tensor{order,dim,T<:Real}
+    Tensor{order,dim,T<:Number}
 
 Tensor type supported for `order ∈ (1,2,4)` and `dim ∈ (1,2,3)`.
 

--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -133,10 +133,10 @@ Base.@propagate_inbounds function tovoigt!(v::AbstractMatrix{T}, A::SymmetricTen
     return v
 end
 
-@inline tomandel(A::SymmetricTensor{o, dim, T}; kwargs...) where{o,dim,T} = tovoigt(A; offdiagscale=T(√2), kwargs...)
+@inline tomandel(A::SymmetricTensor{o, dim, T}; kwargs...) where{o,dim,T} = tovoigt(A; offdiagscale=√(T(2)), kwargs...)
 @inline tomandel(A::Tensor; kwargs...) = tovoigt(A; kwargs...)
 
-Base.@propagate_inbounds tomandel!(v::AbstractVecOrMat{T}, A::SymmetricTensor; kwargs...) where{T} = tovoigt!(v, A; offdiagscale=T(√2), kwargs...)
+Base.@propagate_inbounds tomandel!(v::AbstractVecOrMat{T}, A::SymmetricTensor; kwargs...) where{T} = tovoigt!(v, A; offdiagscale=√(T(2)), kwargs...)
 Base.@propagate_inbounds tomandel!(v::AbstractVecOrMat, A::Tensor; kwargs...) = tovoigt!(v, A; kwargs...)
 
 """
@@ -189,5 +189,5 @@ Base.@propagate_inbounds function fromvoigt(TT::Type{<: SymmetricTensor{4, dim}}
         end)
 end
 
-Base.@propagate_inbounds frommandel(TT::Type{<: SymmetricTensor}, v::AbstractVecOrMat{T}; kwargs...) where{T} = fromvoigt(TT, v; offdiagscale=T(√2), kwargs...)
+Base.@propagate_inbounds frommandel(TT::Type{<: SymmetricTensor}, v::AbstractVecOrMat{T}; kwargs...) where{T} = fromvoigt(TT, v; offdiagscale=√(T(2)), kwargs...)
 Base.@propagate_inbounds frommandel(TT::Type{<: Tensor}, v::AbstractVecOrMat; kwargs...) = fromvoigt(TT, v; kwargs...)

--- a/test/F64.jl
+++ b/test/F64.jl
@@ -40,3 +40,8 @@ Base.convert(::Type{F64}, a::T) where {T <: Number} = F64(a)
 Base.acos(a::F64) = F64(acos(a.x))
 Base.cos(a::F64) = F64(cos(a.x))
 Base.sin(a::F64) = F64(sin(a.x))
+
+# Number type which is not <: Real (Tensors#154)
+struct NotReal <: Number
+    x::Float64
+end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -58,6 +58,8 @@ for dim in (1, 2, 3)
               SymmetricTensor{order,dim,Float32}(z)::SymmetricTensor{order,dim,Float32}
     end
 end
+# Number type which is not <: Real but <: Number (Tensors#154)
+@test Vec{3, NotReal}((1, 2, 3)) isa Vec{3, NotReal}
 end # of testset
 
 @testsection "diagm, one" begin


### PR DESCRIPTION
These changes should allow to use symbolic numbers such as `Sym` from `SymPy.jl` within `Tensors.jl` .