### PR TITLE
Construct from fully specified

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -63,10 +63,7 @@ julia> Tensor{1,3,Float64}((1.0, 2.0, 3.0))
 """
 struct Tensor{order, dim, T, M} <: AbstractTensor{order, dim, T}
     data::NTuple{M, T}
-
-    # this is needed to make Vec{3, Float64}(f::Function) work properly
     Tensor{order, dim, T, M}(data::NTuple) where {order, dim, T, M} = new{order, dim, T, M}(data)
-    #Tensor{order, dim, T, M}(f::Function) where {order, dim, T, M} = new{order, dim, T, M}(NTuple{M, T}(ntuple(f, Val(M))))
 end
 
 ###############

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -66,7 +66,7 @@ struct Tensor{order, dim, T, M} <: AbstractTensor{order, dim, T}
 
     # this is needed to make Vec{3, Float64}(f::Function) work properly
     Tensor{order, dim, T, M}(data::NTuple) where {order, dim, T, M} = new{order, dim, T, M}(data)
-    Tensor{order, dim, T, M}(f::Function) where {order, dim, T, M} = new{order, dim, T, M}(NTuple{M, T}(ntuple(f, Val(M))))
+    #Tensor{order, dim, T, M}(f::Function) where {order, dim, T, M} = new{order, dim, T, M}(NTuple{M, T}(ntuple(f, Val(M))))
 end
 
 ###############

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -151,8 +151,8 @@ end
 # General fallbacks
 @inline          Tensor{order, dim, T}(data::Union{AbstractArray, Tuple, Function}) where {order, dim, T} = convert(Tensor{order, dim, T}, Tensor{order, dim}(data))
 @inline SymmetricTensor{order, dim, T}(data::Union{AbstractArray, Tuple, Function}) where {order, dim, T} = convert(SymmetricTensor{order, dim, T}, SymmetricTensor{order, dim}(data))
-# @inline          Tensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = Tensor{order, dim, T}(data)
-# @inline SymmetricTensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = SymmetricTensor{order, dim, T}(data)
+@inline          Tensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = Tensor{order, dim, T}(data)
+@inline SymmetricTensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = SymmetricTensor{order, dim, T}(data)
 
 include("indexing.jl")
 include("utilities.jl")

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -201,6 +201,17 @@ for T in (Float32, Float64, F64)
                  @test AAf_sym[i,j,k,l] == T(fijkl(i,j,k,l))
             end
         end
+
+        # Test fully specified constructors
+        for vec in (vf,af)
+            @test vec == typeof(vec)(i->vec[i])
+        end
+        for t2 in (Af, Af_sym)
+            @test t2 == typeof(t2)((i,j)->t2[i,j])
+        end
+        for t4 in (AAf, AAf_sym)
+            @test t4 == typeof(t4)((i,j,k,l) -> t4[i,j,k,l])
+        end 
     end
 end
 end # of testset


### PR DESCRIPTION
``` julia
a = rand(SymmetricTensor{2,3})
b = typeof(a)((i,j)-> i==j ? 1.0 : 0.0)
```
did not work before this change was added. 
However, for some unknown reason, 
``` julia
a = rand(Tensor{2,3})
b = typeof(a)((i,j)-> i==j ? 1.0 : 0.0)
```
still fails (also causing the new tests to fail)