### PR TITLE
Correction of bug in minorsymmetric

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -38,7 +38,7 @@ Compute the minor symmetric part of a fourth order tensor, return a `SymmetricTe
             @inbounds if i == j && k == l
                 return S[i,j,k,l]
             else
-                return (S[i,j,k,l] + S[j,i,k,l] + S[i,j,k,l] + S[i,j,l,k]) / 4
+                return (S[i,j,k,l] + S[j,i,k,l] + S[i,j,l,k] + S[j,i,l,k]) / 4
             end
         end
     )

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -19,6 +19,8 @@ AA_sym = rand(SymmetricTensor{4, dim, T})
 BB_sym = rand(SymmetricTensor{4, dim, T})
 A_sym = rand(SymmetricTensor{2, dim, T})
 B_sym = rand(SymmetricTensor{2, dim, T})
+symA = symmetric(A)
+symB = symmetric(B)
 
 i,j,k,l = rand(1:dim,4)
 
@@ -133,6 +135,7 @@ end # of testsection
     @test minorsymmetric(AA_sym) ≈ AA_sym
     @test issymmetric(convert(Tensor,minorsymmetric(AA_sym)))
     @test isminorsymmetric(convert(Tensor,minorsymmetric(AA_sym)))
+    @test minorsymmetric(A⊗B) ≈ symA⊗symB
 
     @test convert(typeof(AA_sym),convert(Tensor,minorsymmetric(AA))) ≈ minorsymmetric(AA)
 


### PR DESCRIPTION
The right formula for "minorsymmetrization" is `(Sᵢⱼₖₗ+Sⱼᵢₖₗ+Sᵢⱼₗₖ+Sⱼᵢₗₖ)/4` and not `(Sᵢⱼₖₗ+Sⱼᵢₖₗ+Sᵢⱼₖₗ+Sᵢⱼₗₖ)/4`