### PR TITLE
Enable insertion of known derivative in autodiff chain

### DIFF
--- a/docs/src/man/automatic_differentiation.md
+++ b/docs/src/man/automatic_differentiation.md
@@ -28,8 +28,6 @@ hessian
 divergence
 curl
 laplace
-insert_gradient
-extract_value
 ```
 
 ## Examples
@@ -93,4 +91,59 @@ julia> E_sym = hessian(ψ, rand(Tensor{2,2}));
 
 julia> norm(majorsymmetric(E) - E_sym)
 0.0
+```
+
+## Inserting a known derivative
+When conditionals are used in a function evaluation, automatic differentiation may yield the wrong result. 
+Consider, the simplified example of the function `f(x) = is_zero(x) ? zero(x) : sin(x)`. If evaluated at `x=0`, 
+the returning of `zero(x)` gives a zero derivative because `zero(x)` is constant, while the correct value is 1. 
+In such cases, it is possible to insert a known derivative of a function which is part of a larger function to
+be automatically differentiated.
+
+Another use case is when the analytical derivative can be computed more efficiently than the automatically 
+differentiatiated derivative.
+
+```@docs
+insert_gradient
+extract_value
+```
+
+### Example
+Lets consider the function ``h(\mathbf{f}(\mathbf{g}(\mathbf{x})))`` where `h(x)=norm(x)`, `f(x)=x ⋅ x`, and `g(x)=dev(x)`. For `f(x)` we 
+then have the analytical derivative 
+```math
+\frac{\partial f_{ij}}{\partial x_{kl}} = \delta_{ik} x_{lj} + x_{ik} \delta_{jl}
+```
+which we can insert into our function by overloading the behavior if the input tensor has dual entries. 
+Below, we compare with the result if we don't overload, and see that the resulting gradients match:
+
+```jldoctest
+# Define functions
+julia> h(x) = norm(x);
+
+julia> f1(x) = x ⋅ x;
+
+julia> f2(x) = f1(x);
+
+julia> g(x) = dev(x);
+
+# Define composed functions
+julia> cfun1(x) = h(f1(g(x)));
+
+julia> cfun2(x) = h(f2(g(x)));
+
+# Insert known derivative for f2 function
+julia> function f2(x::Tensor{2,dim,T}) where{dim, T<:ForwardDiff.Dual}
+    xval = extract_value(x)
+    fval = f2(xval)
+    I2 = one(Tensor{2,dim})
+    ∇f = otimesu(I2, transpose(xval)) + otimesu(xval, I2)
+    return insert_gradient(fval, ∇f, x)
+end;
+
+# Calculate gradients
+julia> x = rand(Tensor{2,2});
+
+julia> gradient(cfun1, x) ≈ gradient(cfun2, x)
+true
 ```

--- a/docs/src/man/automatic_differentiation.md
+++ b/docs/src/man/automatic_differentiation.md
@@ -102,7 +102,7 @@ correct value is 1. In such cases, it is possible to insert a known
 derivative of a function which is part of a larger function to be 
 automatically differentiated.
 
-Another use case is when the analytical derivative can be computed more 
+Another use case is when the analytical derivative can be computed much more 
 efficiently than the automatically differentiatiated derivative.
 
 ```@docs

--- a/docs/src/man/automatic_differentiation.md
+++ b/docs/src/man/automatic_differentiation.md
@@ -28,6 +28,8 @@ hessian
 divergence
 curl
 laplace
+insert_gradient
+extract_value
 ```
 
 ## Examples

--- a/docs/src/man/automatic_differentiation.md
+++ b/docs/src/man/automatic_differentiation.md
@@ -94,56 +94,61 @@ julia> norm(majorsymmetric(E) - E_sym)
 ```
 
 ## Inserting a known derivative
-When conditionals are used in a function evaluation, automatic differentiation may yield the wrong result. 
-Consider, the simplified example of the function `f(x) = is_zero(x) ? zero(x) : sin(x)`. If evaluated at `x=0`, 
-the returning of `zero(x)` gives a zero derivative because `zero(x)` is constant, while the correct value is 1. 
-In such cases, it is possible to insert a known derivative of a function which is part of a larger function to
-be automatically differentiated.
+When conditionals are used in a function evaluation, automatic differentiation 
+may yield the wrong result. Consider, the simplified example of the function 
+`f(x) = is_zero(x) ? zero(x) : sin(x)`. If evaluated at `x=0`, the returning 
+of `zero(x)` gives a zero derivative because `zero(x)` is constant, while the 
+correct value is 1. In such cases, it is possible to insert a known 
+derivative of a function which is part of a larger function to be 
+automatically differentiated.
 
-Another use case is when the analytical derivative can be computed more efficiently than the automatically 
-differentiatiated derivative.
+Another use case is when the analytical derivative can be computed more 
+efficiently than the automatically differentiatiated derivative.
 
 ```@docs
-insert_gradient
-extract_value
+@implement_gradient
 ```
 
 ### Example
-Lets consider the function ``h(\mathbf{f}(\mathbf{g}(\mathbf{x})))`` where `h(x)=norm(x)`, `f(x)=x ⋅ x`, and `g(x)=dev(x)`. For `f(x)` we 
+Lets consider the function ``h(\mathbf{f}(\mathbf{g}(\mathbf{x})))`` 
+where `h(x)=norm(x)`, `f(x)=x ⋅ x`, and `g(x)=dev(x)`. For `f(x)` we 
 then have the analytical derivative 
 ```math
 \frac{\partial f_{ij}}{\partial x_{kl}} = \delta_{ik} x_{lj} + x_{ik} \delta_{jl}
 ```
-which we can insert into our function by overloading the behavior if the input tensor has dual entries. 
-Below, we compare with the result if we don't overload, and see that the resulting gradients match:
+which we can insert into our known analytical derivative using the
+ `@implement_gradient` macro. Below, we compare with the result when 
+ the full derivative is calculated using automatic differentiation.
 
 ```jldoctest
 # Define functions
-julia> h(x) = norm(x);
-
-julia> f1(x) = x ⋅ x;
-
-julia> f2(x) = f1(x);
-
-julia> g(x) = dev(x);
+h(x) = norm(x)
+f1(x) = x ⋅ x
+f2(x) = f1(x)
+g(x) = dev(x)
 
 # Define composed functions
-julia> cfun1(x) = h(f1(g(x)));
+cfun1(x) = h(f1(g(x)))
+cfun2(x) = h(f2(g(x)))
 
-julia> cfun2(x) = h(f2(g(x)));
-
-# Insert known derivative for f2 function
-julia> function f2(x::Tensor{2,dim,T}) where{dim, T<:ForwardDiff.Dual}
-    xval = extract_value(x)
-    fval = f2(xval)
+# Define known derivative
+function df2dx(x::Tensor{2,dim}) where{dim}
+    println("Hello from df2dx") # Show that df2dx is called
+    fval = f2(x)
     I2 = one(Tensor{2,dim})
-    ∇f = otimesu(I2, transpose(xval)) + otimesu(xval, I2)
-    return insert_gradient(fval, ∇f, x)
-end;
+    dfdx_val = otimesu(I2, transpose(x)) + otimesu(x, I2)
+    return fval, dfdx_val
+end
+
+# Implement known derivative
+@implement_gradient f2 df2dx
 
 # Calculate gradients
-julia> x = rand(Tensor{2,2});
+x = rand(Tensor{2,2})
 
-julia> gradient(cfun1, x) ≈ gradient(cfun2, x)
+gradient(cfun1, x) ≈ gradient(cfun2, x)
+
+# output
+Hello from df2dx
 true
 ```

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -19,7 +19,7 @@ export otimesu, otimesl
 export minortranspose, majortranspose, isminorsymmetric, ismajorsymmetric
 export tdot, dott, dotdot
 export hessian, gradient, curl, divergence, laplace
-export insert_gradient, extract_value
+export @implement_gradient
 export basevec, eᵢ
 export rotate
 export tovoigt, tovoigt!, fromvoigt, tomandel, tomandel!, frommandel

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -19,6 +19,7 @@ export otimesu, otimesl
 export minortranspose, majortranspose, isminorsymmetric, ismajorsymmetric
 export tdot, dott, dotdot
 export hessian, gradient, curl, divergence, laplace
+export insert_gradient, extract_value
 export basevec, eᵢ
 export rotate
 export tovoigt, tovoigt!, fromvoigt, tomandel, tomandel!, frommandel

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -251,7 +251,7 @@ function insert_gradient(f::Number, dfdg::SecondOrderTensor{dim}, g::SecondOrder
     return Dual{Tg}(f, get_data(dfdx))
 end
 
-function _insert_gradient(f::Vec{dim}, dfdg::Tensor{2,dim}, g::Vec{dim, <:Dual{Tg}}) where{dim,Tg}
+function insert_gradient(f::Vec{dim}, dfdg::Tensor{2,dim}, g::Vec{dim, <:Dual{Tg}}) where{dim,Tg}
     fdata = get_data(f)
     dgdx = _extract_gradient(g, _get_original_gradient_input(g))
     dfdx = dfdg ⋅ dgdx
@@ -261,7 +261,7 @@ function _insert_gradient(f::Vec{dim}, dfdg::Tensor{2,dim}, g::Vec{dim, <:Dual{T
     return y
 end
 
-function _insert_gradient(f::SecondOrderTensorN{dim, <:Any, N}, dfdg::FourthOrderTensor{dim}, g::SecondOrderTensorN{dim,<:Dual{Tg},N}) where{dim,Tg,N}
+function insert_gradient(f::SecondOrderTensorN{dim, <:Any, N}, dfdg::FourthOrderTensor{dim}, g::SecondOrderTensorN{dim,<:Dual{Tg},N}) where{dim,Tg,N}
     fdata = get_data(f)
     dgdx = _extract_gradient(g, _get_original_gradient_input(g))
     dfdx = dfdg ⊡ dgdx

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -225,7 +225,7 @@ function _insert_gradient(f::Number, ∇f::Tensor{2,dim}, x::Tensor{2,dim,<:Dual
     diffdata = get_data(∇f ⊡ _extract_gradient(x, prev_input_for_type_info))
     dim2 = dim^2
     @inbounds begin
-    y = Dual{Tg}(f, ntuple(j->diffdata[j],dim2))
+    y = Dual{Tg}(f, diffdata)
     end
     return y
 end

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -220,6 +220,16 @@ function _insert_gradient(f::Tensor{2,dim}, ∇f::Tensor{4,dim}, x::Tensor{2,dim
     return y
 end
 
+function _insert_gradient(f::Number, ∇f::Tensor{2,dim}, x::Tensor{2,dim,<:Dual{Tg}}) where{dim,Tg}
+    prev_input_for_type_info = _get_prev_input_for_type_info(x)
+    diffdata = get_data(_extract_gradient(x, prev_input_for_type_info) ⊡ ∇f)
+    dim2 = dim^2
+    @inbounds begin
+    y = Dual{Tg}(f, ntuple(j->diffdata[j],dim2))
+    end
+    return y
+end
+
 
 ##################
 # Load functions #

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -212,7 +212,7 @@ _get_prev_input_for_type_info(::Dual{Tg, V, 9}, ::Val{2}, ::Val{3}) where{Tg,V} 
 function _insert_gradient(f::Tensor{2,dim}, ∇f::Tensor{4,dim}, x::Tensor{2,dim,<:Dual{Tg}}) where{dim,Tg}
     fdata = get_data(f)
     prev_input_for_type_info = _get_prev_input_for_type_info(x)
-    diffdata = get_data(_extract_gradient(x, prev_input_for_type_info) ⊡ ∇f)
+    diffdata = get_data(∇f ⊡ _extract_gradient(x, prev_input_for_type_info))
     dim2 = Int(dim^2)
     @inbounds begin
     y = Tensor{2,dim}(ntuple(i->Dual{Tg}(fdata[i], ntuple(j->diffdata[i+dim2*(j-1)],dim2)), dim2))
@@ -222,7 +222,7 @@ end
 
 function _insert_gradient(f::Number, ∇f::Tensor{2,dim}, x::Tensor{2,dim,<:Dual{Tg}}) where{dim,Tg}
     prev_input_for_type_info = _get_prev_input_for_type_info(x)
-    diffdata = get_data(_extract_gradient(x, prev_input_for_type_info) ⊡ ∇f)
+    diffdata = get_data(∇f ⊡ _extract_gradient(x, prev_input_for_type_info))
     dim2 = dim^2
     @inbounds begin
     y = Dual{Tg}(f, ntuple(j->diffdata[j],dim2))

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -186,6 +186,41 @@ for TensorType in (Tensor, SymmetricTensor)
     end
 end
 
+######################
+# Gradient insertion #
+######################
+
+# Inserters are supposed to take a tensor of real values and convert it
+# into a tensor of dual values where the seeds are correctly defined.
+
+# Insertions get the real value and derivative of a function, as well 
+# a tensor of dual values that was the initial input to that function. 
+# A new tensor of dual values are then created, to emulate the function
+# being run with dual numbers (i.e. inserting the analytical gradient)
+# As opposed to with gradient extraction, we cannot know the input given 
+# to the previous function, except by inspection of the input tensor with 
+# dual entries: The number of partials (of the entry) together with order 
+# and dimension of the input tensor allow us to deduce this for a regular 
+# tensor. 
+
+_get_prev_input_for_type_info(x::Tensor{order,dim,<:Dual}) where{order,dim} = _get_prev_input_for_type_info(x[1], Val{order}(), Val{dim}())
+_get_prev_input_for_type_info(::Dual{Tg, V, dim}, ::Val{1}, ::Val{dim}) where{Tg,V,dim} = one(Tensor{1,dim,V})
+_get_prev_input_for_type_info(::Dual{Tg, V, 1}, ::Val{2}, ::Val{1}) where{Tg,V} = one(Tensor{2,1,V})
+_get_prev_input_for_type_info(::Dual{Tg, V, 4}, ::Val{2}, ::Val{2}) where{Tg,V} = one(Tensor{2,2,V})
+_get_prev_input_for_type_info(::Dual{Tg, V, 9}, ::Val{2}, ::Val{3}) where{Tg,V} = one(Tensor{2,3,V})
+
+function _insert_gradient(f::Tensor{2,dim}, ∇f::Tensor{4,dim}, x::Tensor{2,dim,<:Dual{Tg}}) where{dim,Tg}
+    fdata = get_data(f)
+    prev_input_for_type_info = _get_prev_input_for_type_info(x)
+    diffdata = get_data(_extract_gradient(x, prev_input_for_type_info) ⊡ ∇f)
+    dim2 = Int(dim^2)
+    @inbounds begin
+    y = Tensor{2,dim}(ntuple(i->Dual{Tg}(fdata[i], ntuple(j->diffdata[i+dim2*(j-1)],dim2)), dim2))
+    end
+    return y
+end
+
+
 ##################
 # Load functions #
 ##################

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -226,21 +226,28 @@ end
     @implement_gradient(f, f_dfdx)
 
 This macro allows specifying a function `f_dfdx` that provides an analytical 
-derivative of the function `f`, and is invoked when f is differentiated 
-using automatic differentiation (based on ForwardDiff, e.g. `Tensors.jl`'s 
-[`gradient`](@ref) or [`hessian`](@ref)). The function `f_dfdx` must take
-the same argument as `f` and should return both the value of `f(x)` and 
+derivative of the function `f`, and is invoked when `f` is differentiated 
+using automatic differentiation based on `ForwardDiff.jl`
+(e.g. when using `Tensors.jl`'s 
+[`gradient`](@ref) or [`hessian`](@ref)), or one of `ForwardDiff.jl`'s API).
+The function `f_dfdx` must take
+the same argument as `f` and should return both the value of `f` and 
 the gradient, i.e. `fval, dfdx_val = f_dfdx(x)`. The following combinations
 of input and output types are supported:
 
 | `x`                 | `f(x)`              | `dfdx`              |
-|---------------------|---------------------|---------------------|
+|:--------------------|:--------------------|:--------------------|
 | `Number`            | `Number`            | `Number`            |
 | `Number`            | `Vec`               | `Vec`               |
 | `Number`            | `SecondOrderTensor` | `SecondOrderTensor` |
-| `Vec`               | `Vec`               | `SecondOrderTensor` |
+| `Vec`               | `Number`            | `Vec`               |
+| `Vec`               | `Vec`               | `Tensor{2}`         |
 | `SecondOrderTensor` | `Number`            | `SecondOrderTensor` |
 | `SecondOrderTensor` | `SecondOrderTensor` | `FourthOrderTensor` |
+
+Note that if one tensor if of symmetric type, then all tensors must 
+be of symmetric type
+
 """
 macro implement_gradient(f, f_dfdx)
     return :($(esc(f))(x :: Union{AbstractTensor{<:Any, <:Any, <:Dual}, Dual}) = _propagate_gradient($(esc(f_dfdx)), x))

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -128,6 +128,10 @@ end
     TensorType(@inline function(i,j,k,l) @inbounds S1[i,j] * S2[k,l]; end)
 end
 
+@inline otimes(S1::Number, S2::Number) = S1*S2
+@inline otimes(S1::AbstractTensor, S2::Number) = S1*S2
+@inline otimes(S1::Number, S2::AbstractTensor) = S1*S2
+
 const ⊗ = otimes
 
 """


### PR DESCRIPTION
This PR considers creating a mechanism for inserting a known derivative into a function that is part of a chain of functions differentiated using the `Tensors.jl`'s `gradient` method. ~~The new method is `insert_gradient`, and `extract_value` has also been exported.~~ Using the suggestion from @KristofferC below, it introduces the macro `@implement_gradient` 

The main goal is to be able to provide analytical derivatives when automatic differentiation fails, see e.g. #174 .
As a side benefit, if a known analytical derivative of part of a function that is slow to call using dual numbers, this method can be used to provide a more efficient implementation (not the case for most functions in `Tensors.jl` though)

Updated example (cases in a comment below are outdated, see also docs):
```julia
using Tensors
# The function to be given a known gradient
f(x) = x⋅x
# Define function to calculate both value and analytical derivative
function f_dfdx(x::Tensor{2,dim}) where{dim}
    fval = f(x)
    I2 = one(Tensor{2,dim})
    df = otimesu(I2, transpose(x)) + otimesu(x, I2)
    return fval, df
end
# Connect the analytical derivative for `f` to `f_dfdx`
@implement_gradient f f_dfdx
```

Suggestions to improve the method are very welcome! 

~~In order to work for #174 / #175 specifically, it seems to require support for 3rd order tensors if we don't want an ad-hoc fix for the specific differentiation case (because we differentiate an (eigen)vector wrt. to a 2nd order at some point in the differentiation chain). I guess supporting 3rd order should be a separate PR though~~

#174 can now be solved with this PR if the user manually provides the derivative for their specific function. This PR might be used to solve AD of `Tensors.jl`'s eigenvector calculation, but requires dealing with 3rd order tensors and is not considered here. 

#### Help wanted
- [x] Decide if functionality (`_insert_gradient`) should be API or remain internal: @fredrikekre suggested to make public.
- ~~Potential efficiency gains? (in some cases much slower execution time, but also sometimes faster)~~: OK for now

#### Remaining tasks
- [x] Support symmetric tensors
- [x] Add tests
- [x] Add documentation
