### PR TITLE
Eigen: Use Mandel representation for 4th order eigen

### DIFF
--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -242,13 +242,9 @@ See also [`eigvals`](@ref) and [`eigvecs`](@ref).
 function LinearAlgebra.eigen(R::SymmetricTensor{4,dim,T′}) where {dim,T′}
     S = ustrip(R)
     T = eltype(S)
-    # Scale from the right only; tovoigt(S; offdiagscale=2) scales from left and right.
-    S′ = SymmetricTensor{4,dim,T}((i,j,k,l) -> k == l ? S[i,j,k,l] : 2*S[i,j,k,l])
-    v = tovoigt(S′)
-    E = eigen(v)
-    perm = sortperm(E.values)
-    values = T′[T′(E.values[i]) for i in perm]
-    vectors = [fromvoigt(SymmetricTensor{2,dim,T}, view(E.vectors, :, i)) for i in perm]
+    E = eigen(Hermitian(tomandel(S)))
+    values = E.values isa Vector{T′} ? E.values : T′[T′(v) for v in E.values]
+    vectors = [frommandel(SymmetricTensor{2,dim,T}, view(E.vectors, :, i)) for i in 1:size(E.vectors, 2)]
     return FourthOrderEigen(values, vectors)
 end
 


### PR DESCRIPTION
This lets us dispatch to LAPACKs symmetric eigenvalue solver, and also
makes sure that the returned eigentensors are normalized.