### PR TITLE
Restrict constructors for heterogeneous tuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensors"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.11.0"
+version = "1.11.1"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -135,10 +135,18 @@ for TensorType in (SymmetricTensor, Tensor)
             @inline $TensorType{$order, $dim}(t::NTuple{$N, T}) where {T} = $TensorType{$order, $dim, T, $N}(t)
             @inline $TensorType{$order, $dim, T1}(t::NTuple{$N, T2}) where {T1, T2} = $TensorType{$order, $dim, T1, $N}(t)
         end
+        if N > 1 # To avoid overwriting ::Tuple{Any}
+            # Heterogeneous tuple
+            @eval @inline $TensorType{$order, $dim}(t::Tuple{Vararg{<:Any,$N}}) = $TensorType{$order, $dim}(promote(t...))
+        end
     end
     if TensorType == Tensor
         for dim in (1, 2, 3)
             @eval @inline Tensor{1, $dim}(t::NTuple{$dim, T}) where {T} = Tensor{1, $dim, T, $dim}(t)
+            if dim > 1 # To avoid overwriting ::Tuple{Any}
+                # Heterogeneous tuple
+                @eval @inline Tensor{1, $dim}(t::Tuple{Vararg{<:Any,$dim}}) = Tensor{1, $dim}(promote(t...))
+            end
         end
     end
 end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -57,16 +57,6 @@ end
     end
 end
 
-# Tensor from heterogeneous Tuple
-function Tensor{order, dim}(data::Tuple) where {order, dim}
-    return Tensor{order,dim}(promote(data...))
-end
-
-# SymmetricTensor from heterogeneous Tuple
-function SymmetricTensor{order, dim}(data::Tuple) where {order, dim}
-    return SymmetricTensor{order,dim}(promote(data...))
-end
-
 # one (identity tensor)
 for TensorType in (SymmetricTensor, Tensor)
     @eval begin

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -42,20 +42,22 @@ for dim in (1, 2, 3)
     z(i, jkl...) = i % 2 == 0 ? 0 : float(0)
     @test Vec{dim}(ntuple(z, dim))::Vec{dim,Float64} ==
           Vec{dim}(z)::Vec{dim,Float64}
-    # @test Vec{dim,Float32}(ntuple(z, dim))::Vec{dim,Float32} ==
-    #       Vec{dim,Float32}(z)::Vec{dim,Float32}
+    @test Vec{dim,Float32}(ntuple(z, dim))::Vec{dim,Float32} ==
+          Vec{dim,Float32}(z)::Vec{dim,Float32}
     for order in (1, 2, 4)
         N = Tensors.n_components(Tensor{order,dim})
         @test Tensor{order,dim}(ntuple(z, N))::Tensor{order,dim,Float64} ==
               Tensor{order,dim}(z)::Tensor{order,dim,Float64}
         @test Tensor{order,dim,Float32}(ntuple(z, N))::Tensor{order,dim,Float32} ==
               Tensor{order,dim,Float32}(z)::Tensor{order,dim,Float32}
+        @test_throws MethodError Tensor{order,dim}(ntuple(z, N+1))
         order == 1 && continue
         N = Tensors.n_components(SymmetricTensor{order,dim})
         @test SymmetricTensor{order,dim}(ntuple(z, N))::SymmetricTensor{order,dim,Float64} ==
               SymmetricTensor{order,dim}(z)::SymmetricTensor{order,dim,Float64}
         @test SymmetricTensor{order,dim,Float32}(ntuple(z, N))::SymmetricTensor{order,dim,Float32} ==
               SymmetricTensor{order,dim,Float32}(z)::SymmetricTensor{order,dim,Float32}
+        @test_throws MethodError SymmetricTensor{order,dim}(ntuple(z, N+1))
     end
 end
 # Number type which is not <: Real but <: Number (Tensors#154)

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -389,7 +389,7 @@ for T in (Float32, Float64), dim in (1, 2, 3)
             if i == j
                 @test E.vectors[i] ⊡ E.vectors[j] ≈ 1
             else
-                @test E.vectors[i] ⊡ E.vectors[j] ≈ 0 atol=5eps(T)
+                @test E.vectors[i] ⊡ E.vectors[j] ≈ 0 atol=10eps(T)
             end
         end
         S′ += E.values[i] * (E.vectors[i] ⊗ E.vectors[i])


### PR DESCRIPTION
This restrict the constructors for heterogeneous tuples from https://github.com/Ferrite-FEM/Tensors.jl/pull/131 to
tuples of the correct length. This avoids a stack overflow when passing
tuples of wrong length. Fixes https://github.com/Ferrite-FEM/Tensors.jl/issues/140, https://github.com/Ferrite-FEM/Tensors.jl/issues/141.