### PR TITLE
Export rotation_tensor and add implementation for 2D

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensors"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.11.1"
+version = "1.12.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -22,7 +22,7 @@ export tdot, dott, dotdot
 export hessian, gradient, curl, divergence, laplace
 export @implement_gradient
 export basevec, eᵢ
-export rotate
+export rotate, rotation_tensor
 export tovoigt, tovoigt!, fromvoigt, tomandel, tomandel!, frommandel
 #########
 # Types #

--- a/test/F64.jl
+++ b/test/F64.jl
@@ -42,6 +42,7 @@ Base.convert(::Type{F64}, a::T) where {T <: Number} = F64(a)
 Base.acos(a::F64) = F64(acos(a.x))
 Base.cos(a::F64) = F64(cos(a.x))
 Base.sin(a::F64) = F64(sin(a.x))
+Base.sincos(a::F64) = (F64(sin(a.x)), F64(cos(a.x)))
 Base.precision(::Type{F64}) = precision(Float64)
 Base.floatmin(::Type{F64}) = floatmin(Float64)
 


### PR DESCRIPTION
This patch exports the existing rotation_matrix function, and adds a new method rotation_matrix(x::Number) which returns the two-dimensional rotation matrix for rotation x radians around the out-of-plane axis.