### PR TITLE
Faster iszero for symmetric tensors

### DIFF
--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -61,3 +61,5 @@ end
         @inbounds return SymmetricTensor{2, dim}($exps)
     end
 end
+
+Base.iszero(a::AbstractTensor) = all(iszero, get_data(a))

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -170,8 +170,8 @@ for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Te
         @test (@inferred fp3(t))::typeof(t) ≈ t ⋅ t ⋅ t
     end
 
-    @test iszero(zero(TensorType{order,dim}))
-    @test !iszero(rand(TensorType{order,dim}))
+    @test iszero(zero(TensorType{order,dim,T}))
+    @test !iszero(ones(TensorType{order,dim,T}))
 end
 end # of testset
 

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -169,6 +169,9 @@ for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Te
         @test (@inferred fp2(t))::typeof(t) ≈ t ⋅ t
         @test (@inferred fp3(t))::typeof(t) ≈ t ⋅ t ⋅ t
     end
+
+    @test iszero(zero(TensorType{order,dim}))
+    @test !iszero(rand(TensorType{order,dim}))
 end
 end # of testset
 


### PR DESCRIPTION
Results for a few all-zero symmetric tensors where the difference is significant
```julia
SymmetricTensor{2, 3, Float64, 6}: 
  16.416 ns (0 allocations: 0 bytes) #master
  3.800 ns (0 allocations: 0 bytes) #pr
SymmetricTensor{4, 2, Float64, 9}: 
  54.205 ns (0 allocations: 0 bytes) #master
  4.700 ns (0 allocations: 0 bytes) #pr
SymmetricTensor{4, 3, Float64, 36}:
  245.130 ns (0 allocations: 0 bytes) #master
  20.281 ns (0 allocations: 0 bytes) #pr
  ```
Full code and results:
```julia 
using Tensors, BenchmarkTools
iszero_pr(a::AbstractTensor) = all(iszero, Tensors.get_data(a))
 for order in (2,4)
        for dim in (1,2,3)
         a = zero(Tensor{order,dim})
         b = rand(Tensor{order,dim})
         as=zero(SymmetricTensor{order,dim})
         bs = rand(SymmetricTensor{order,dim})
         println("order=$order, dim=$dim")
         for t in (a, as, b, bs)
          println(typeof(t), iszero(t) ? ": all zeros" : ": random")
          @btime iszero($t)
          @btime iszero_pr($t)
         end
        end
       end
order=2, dim=1
Tensor{2, 1, Float64, 1}: all zeros
  1.400 ns (0 allocations: 0 bytes)
  1.400 ns (0 allocations: 0 bytes)
SymmetricTensor{2, 1, Float64, 1}: all zeros
  1.400 ns (0 allocations: 0 bytes)
  1.400 ns (0 allocations: 0 bytes)
Tensor{2, 1, Float64, 1}: random
  1.400 ns (0 allocations: 0 bytes)
  1.400 ns (0 allocations: 0 bytes)
SymmetricTensor{2, 1, Float64, 1}: random
  1.400 ns (0 allocations: 0 bytes)
  1.400 ns (0 allocations: 0 bytes)
order=2, dim=2
Tensor{2, 2, Float64, 4}: all zeros
  2.100 ns (0 allocations: 0 bytes)
  2.500 ns (0 allocations: 0 bytes)
SymmetricTensor{2, 2, Float64, 3}: all zeros
  6.700 ns (0 allocations: 0 bytes)
  2.300 ns (0 allocations: 0 bytes)
Tensor{2, 2, Float64, 4}: random
  1.600 ns (0 allocations: 0 bytes)
  1.600 ns (0 allocations: 0 bytes)
SymmetricTensor{2, 2, Float64, 3}: random
  2.500 ns (0 allocations: 0 bytes)
  1.600 ns (0 allocations: 0 bytes)
order=2, dim=3
Tensor{2, 3, Float64, 9}: all zeros
  4.200 ns (0 allocations: 0 bytes)
  3.900 ns (0 allocations: 0 bytes)
SymmetricTensor{2, 3, Float64, 6}: all zeros
  16.416 ns (0 allocations: 0 bytes)
  3.800 ns (0 allocations: 0 bytes)
Tensor{2, 3, Float64, 9}: random
  2.300 ns (0 allocations: 0 bytes)
  2.300 ns (0 allocations: 0 bytes)
SymmetricTensor{2, 3, Float64, 6}: random
  4.200 ns (0 allocations: 0 bytes)
  2.100 ns (0 allocations: 0 bytes)
order=4, dim=1
Tensor{4, 1, Float64, 1}: all zeros
  2.400 ns (0 allocations: 0 bytes)
  1.900 ns (0 allocations: 0 bytes)
SymmetricTensor{4, 1, Float64, 1}: all zeros
  2.700 ns (0 allocations: 0 bytes)
  1.900 ns (0 allocations: 0 bytes)
Tensor{4, 1, Float64, 1}: random
  1.900 ns (0 allocations: 0 bytes)
  1.900 ns (0 allocations: 0 bytes)
SymmetricTensor{4, 1, Float64, 1}: random
  3.000 ns (0 allocations: 0 bytes)
  1.900 ns (0 allocations: 0 bytes)
order=4, dim=2
Tensor{4, 2, Float64, 16}: all zeros
  8.800 ns (0 allocations: 0 bytes)
  7.107 ns (0 allocations: 0 bytes)
SymmetricTensor{4, 2, Float64, 9}: all zeros
  54.205 ns (0 allocations: 0 bytes)
  4.700 ns (0 allocations: 0 bytes)
Tensor{4, 2, Float64, 16}: random
  2.400 ns (0 allocations: 0 bytes)
  2.200 ns (0 allocations: 0 bytes)
SymmetricTensor{4, 2, Float64, 9}: random
  3.400 ns (0 allocations: 0 bytes)
  2.400 ns (0 allocations: 0 bytes)
order=4, dim=3
Tensor{4, 3, Float64, 81}: all zeros
  55.703 ns (0 allocations: 0 bytes)
  41.439 ns (0 allocations: 0 bytes)
SymmetricTensor{4, 3, Float64, 36}: all zeros
  245.130 ns (0 allocations: 0 bytes)
  20.281 ns (0 allocations: 0 bytes)
Tensor{4, 3, Float64, 81}: random
  2.200 ns (0 allocations: 0 bytes)
  2.000 ns (0 allocations: 0 bytes)
SymmetricTensor{4, 3, Float64, 36}: random
  3.700 ns (0 allocations: 0 bytes)
  2.100 ns (0 allocations: 0 bytes)
  ```