### PR TITLE
VarArg{Any} instead of VarArg{<:Any}

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -135,7 +135,7 @@ for TensorType in (SymmetricTensor, Tensor)
         end
         if N > 1 # To avoid overwriting ::Tuple{Any}
             # Heterogeneous tuple
-            @eval @inline $TensorType{$order, $dim}(t::Tuple{Vararg{<:Any,$N}}) = $TensorType{$order, $dim}(promote(t...))
+            @eval @inline $TensorType{$order, $dim}(t::Tuple{Vararg{Any,$N}}) = $TensorType{$order, $dim}(promote(t...))
         end
     end
     if TensorType == Tensor
@@ -143,7 +143,7 @@ for TensorType in (SymmetricTensor, Tensor)
             @eval @inline Tensor{1, $dim}(t::NTuple{$dim, T}) where {T} = Tensor{1, $dim, T, $dim}(t)
             if dim > 1 # To avoid overwriting ::Tuple{Any}
                 # Heterogeneous tuple
-                @eval @inline Tensor{1, $dim}(t::Tuple{Vararg{<:Any,$dim}}) = Tensor{1, $dim}(promote(t...))
+                @eval @inline Tensor{1, $dim}(t::Tuple{Vararg{Any,$dim}}) = Tensor{1, $dim}(promote(t...))
             end
         end
     end


### PR DESCRIPTION
I think this should be the fix for the deprecated syntax?