### PR TITLE
Document tomandel/frommandel

### DIFF
--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -136,7 +136,7 @@ end
 """
     tomandel(A; kwargs...)
 
-Convert the tensor `A` to voigt-form using the Mandel convention, see [`tovoigt`](@ref)
+Convert the tensor `A` to voigt-form using the Mandel convention, see [`tovoigt`](@ref).
 """
 @inline tomandel(A::SymmetricTensor{o, dim, T}; kwargs...) where{o,dim,T} = tovoigt(A; offdiagscale=√(2one(T)), kwargs...)
 @inline tomandel(A::Tensor; kwargs...) = tovoigt(A; kwargs...)
@@ -202,7 +202,7 @@ end
 """
     frommandel(TT, v; kwargs...)
 
-Convert the Array `v` in voigt-format, following the Mandel convention, to a tensor of type `TT`, see [`fromvoigt`](@ref)
+Convert the Array `v` in voigt-format, following the Mandel convention, to a tensor of type `TT`, see [`fromvoigt`](@ref).
 """
 Base.@propagate_inbounds frommandel(TT::Type{<: SymmetricTensor}, v::AbstractVecOrMat{T}; kwargs...) where{T} = fromvoigt(TT, v; offdiagscale=√(2one(T)), kwargs...)
 Base.@propagate_inbounds frommandel(TT::Type{<: Tensor}, v::AbstractVecOrMat; kwargs...) = fromvoigt(TT, v; kwargs...)

--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -133,9 +133,19 @@ Base.@propagate_inbounds function tovoigt!(v::AbstractMatrix{T}, A::SymmetricTen
     return v
 end
 
+"""
+    tomandel(A; kwargs...)
+
+Convert the tensor `A` to voigt-form using the Mandel convention, see [`tovoigt`](@ref)
+"""
 @inline tomandel(A::SymmetricTensor{o, dim, T}; kwargs...) where{o,dim,T} = tovoigt(A; offdiagscale=√(2one(T)), kwargs...)
 @inline tomandel(A::Tensor; kwargs...) = tovoigt(A; kwargs...)
 
+"""
+    tomandel!(v, A; kwargs...)
+
+Fill the array `v` with the values in `A` on voigt-form using the Mandel convention, see [`tovoigt!`](@ref).
+"""
 Base.@propagate_inbounds tomandel!(v::AbstractVecOrMat{T}, A::SymmetricTensor; kwargs...) where{T} = tovoigt!(v, A; offdiagscale=√(2one(T)), kwargs...)
 Base.@propagate_inbounds tomandel!(v::AbstractVecOrMat, A::Tensor; kwargs...) = tovoigt!(v, A; kwargs...)
 
@@ -189,5 +199,10 @@ Base.@propagate_inbounds function fromvoigt(TT::Type{<: SymmetricTensor{4, dim}}
         end)
 end
 
+"""
+    frommandel(TT, v; kwargs...)
+
+Convert the Array `v` in voigt-format, following the Mandel convention, to a tensor of type `TT`, see [`fromvoigt`](@ref)
+"""
 Base.@propagate_inbounds frommandel(TT::Type{<: SymmetricTensor}, v::AbstractVecOrMat{T}; kwargs...) where{T} = fromvoigt(TT, v; offdiagscale=√(2one(T)), kwargs...)
 Base.@propagate_inbounds frommandel(TT::Type{<: Tensor}, v::AbstractVecOrMat; kwargs...) = fromvoigt(TT, v; kwargs...)


### PR DESCRIPTION
Noticed during teaching that there are no docstrings for to/from mandel