### PR TITLE
Faster inverse of 4th order Tensors

### DIFF
--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -150,11 +150,11 @@ end
 end
 
 function Base.inv(t::Tensor{4, dim}) where {dim}
-    fromvoigt(Tensor{4, dim}, inv(tovoigt(t)))
+    fromvoigt(Tensor{4, dim}, inv(tovoigt(SMatrix, t)))
 end
 
 function Base.inv(t::SymmetricTensor{4, dim, T}) where {dim, T}
-    frommandel(SymmetricTensor{4, dim}, inv(tomandel(t)))
+    frommandel(SymmetricTensor{4, dim}, inv(tomandel(SMatrix, t)))
 end
 
 Base.:\(S1::SecondOrderTensor, S2::AbstractTensor) = inv(S1) ⋅ S2

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -150,12 +150,21 @@ end
 end
 
 function Base.inv(t::Tensor{4, dim}) where {dim}
-    fromvoigt(Tensor{4, dim}, inv(tovoigt(SMatrix, t)))
+    fromvoigt(Tensor{4, dim}, inv(tovoigt(t)))
 end
 
 function Base.inv(t::SymmetricTensor{4, dim, T}) where {dim, T}
+    frommandel(SymmetricTensor{4, dim}, inv(tomandel(t)))
+end
+
+function Base.inv(t::Tensor{4, dim, <:Real}) where {dim}
+    fromvoigt(Tensor{4, dim}, inv(tovoigt(SMatrix, t)))
+end
+
+function Base.inv(t::SymmetricTensor{4, dim, T}) where {dim, T<:Real}
     frommandel(SymmetricTensor{4, dim}, inv(tomandel(SMatrix, t)))
 end
+
 
 Base.:\(S1::SecondOrderTensor, S2::AbstractTensor) = inv(S1) ⋅ S2
 


### PR DESCRIPTION
Profit from fast + allocation free `StaticArrays` inverses
```julia
julia> A = rand(Tensor{4,3}); Asym = symmetric(A);       

# on master
julia> @btime inv($A);                                                                                                                                                                                                                    
  1.321 μs (5 allocations: 6.19 KiB)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                          
julia> @btime inv($Asym);                                                                                                                                                                                                                 
  723.881 ns (5 allocations: 3.95 KiB)                                                                                                                                                                                                    

# on PR                                                                                                                                                                                                                                          
julia> @btime inv($A);                                                                                                                                                                                                                    
  564.087 ns (0 allocations: 0 bytes)                                                                                                                                                                                                     
                                                                                                                                                                                                                                          
julia> @btime inv($Asym);                                                                                                                                                                                                                 
  187.091 ns (0 allocations: 0 bytes)  
```