### PR TITLE
3rd order tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [1.15.1]
+## [1.16.0]
+
 ### Added
  - Partial support for 3rd order Tensors [#205][github-205]
     * All construction methods, e.g. `zero(Tensor{3})`, `rand(Tensor{3})`, `Tensor{3}((i,j,k)->f(i,j,k))`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Tensors changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [1.15.1]
+### Added
+ - Partial support for 3rd order Tensors [#205][github-205]
+    * All construction methods, e.g. `zero(Tensor{3})`, `rand(Tensor{3})`, `Tensor{3}((i,j,k)->f(i,j,k))`
+    * Gradient of 2nd order tensor wrt. vector
+    * `rotate(::Tensor{3})`
+    * `dcontract(::Tensor{D1}, ::Tensor{D2})` for (D1,D2) in ((2,3), (3,2), (3,4), (4,3))
+    * `otimes(::Vec, ::SecondOrderTensor)` and `otimes(::SecondOrderTensor, ::Vec)`
+    * `dot(::Tensor{D1}, ::Tensor{D2})` for (D1,D2) in ((3,1), (1,3), (2,3), (3,2))
+
+<!-- Release links -->
+[Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v1.15.1...HEAD
+[1.15.1]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v1.15.0...v1.15.1
+
+<!-- GitHub pull request/issue links -->
+[github-205]: https://github.com/Ferrite-FEM/Tensors.jl/pull/205

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * `dot(::Tensor{D1}, ::Tensor{D2})` for (D1,D2) in ((3,1), (1,3), (2,3), (3,2))
 
 <!-- Release links -->
-[Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v1.15.1...HEAD
-[1.15.1]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v1.15.0...v1.15.1
+[Unreleased]: https://github.com/Ferrite-FEM/Tensors.jl/compare/v1.15.1...HEAD
+[1.15.1]: https://github.com/Ferrite-FEM/Tensors.jl/compare/v1.15.0...v1.15.1
 
 <!-- GitHub pull request/issue links -->
 [github-205]: https://github.com/Ferrite-FEM/Tensors.jl/pull/205

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensors"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.15.0"
+version = "1.16.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -73,7 +73,7 @@ const Vec{dim, T, M} = Tensor{1, dim, T, dim}
 
 const AllTensors{dim, T} = Union{SymmetricTensor{2, dim, T}, Tensor{2, dim, T},
                                  SymmetricTensor{4, dim, T}, Tensor{4, dim, T},
-                                 Vec{dim, T}}
+                                 Vec{dim, T}, Tensor{3, dim, T}}
 
 
 const SecondOrderTensor{dim, T}   = Union{SymmetricTensor{2, dim, T}, Tensor{2, dim, T}}

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -118,16 +118,17 @@ Base.IndexStyle(::Type{<:Tensor}) = IndexLinear()
 ########
 Base.size(::Vec{dim})               where {dim} = (dim,)
 Base.size(::SecondOrderTensor{dim}) where {dim} = (dim, dim)
+Base.size(::Tensor{3,dim})          where {dim} = (dim, dim, dim)
 Base.size(::FourthOrderTensor{dim}) where {dim} = (dim, dim, dim, dim)
 
-# Also define lnegth for the type itself
+# Also define length for the type itself
 Base.length(::Type{Tensor{order, dim, T, M}}) where {order, dim, T, M} = M
 
 #########################
 # Internal constructors #
 #########################
-for TensorType in (SymmetricTensor, Tensor)
-    for order in (2, 4), dim in (1, 2, 3)
+for (TensorType, orders) in ((SymmetricTensor, (2,4)), (Tensor, (2,3,4)))
+    for order in orders, dim in (1, 2, 3)
         N = n_components(TensorType{order, dim})
         @eval begin
             @inline $TensorType{$order, $dim}(t::NTuple{$N, T}) where {T} = $TensorType{$order, $dim, T, $N}(t)

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -121,6 +121,14 @@ end
     end
     return ∇f
 end
+# Tensor{2} output, Vec input -> Tensor{3} gradient
+@inline function _extract_gradient(v::Tensor{2, 1, <: Dual}, ::Vec{1})
+    @inbounds begin
+        p1 = partials(v[1,1])
+        ∇f = Tensor{3, 1}((p1[1],))
+    end
+    return ∇f
+end
 # Tensor{2} output, Tensor{2} input -> Tensor{4} gradient
 @inline function _extract_gradient(v::Tensor{2, 2, <: Dual}, ::Tensor{2, 2})
     @inbounds begin
@@ -139,6 +147,15 @@ end
         ∇f = SymmetricTensor{4, 2}((p1[1], p2[1], p3[1],
                                     p1[2], p2[2], p3[2],
                                     p1[3], p2[3], p3[3]))
+    end
+    return ∇f
+end
+# Tensor{2} output, Vec input -> Tensor{3} gradient
+@inline function _extract_gradient(v::Tensor{2, 2, <: Dual}, ::Vec{2})
+    @inbounds begin
+        p1, p2, p3, p4 = partials(v[1,1]), partials(v[2,1]), partials(v[1,2]), partials(v[2,2])
+        ∇f = Tensor{3, 2}((p1[1], p2[1], p3[1], p4[1],
+                           p1[2], p2[2], p3[2], p4[2]))
     end
     return ∇f
 end
@@ -171,6 +188,19 @@ end
                                     p1[4], p2[4], p3[4], p4[4], p5[4], p6[4],
                                     p1[5], p2[5], p3[5], p4[5], p5[5], p6[5],
                                     p1[6], p2[6], p3[6], p4[6], p5[6], p6[6]))
+    end
+    return ∇f
+end
+
+# Tensor{2} output, Vec input -> Tensor{3} gradient
+@inline function _extract_gradient(v::Tensor{2, 3, <: Dual}, ::Vec{3})
+    @inbounds begin
+        p1, p2, p3 = partials(v[1,1]), partials(v[2,1]), partials(v[3,1])
+        p4, p5, p6 = partials(v[1,2]), partials(v[2,2]), partials(v[3,2])
+        p7, p8, p9 = partials(v[1,3]), partials(v[2,3]), partials(v[3,3])
+        ∇f = Tensor{3, 3}((p1[1], p2[1], p3[1], p4[1], p5[1], p6[1], p7[1], p8[1], p9[1],
+                           p1[2], p2[2], p3[2], p4[2], p5[2], p6[2], p7[2], p8[2], p9[2],  
+                           p1[3], p2[3], p3[3], p4[3], p5[3], p6[3], p7[3], p8[3], p9[3]))
     end
     return ∇f
 end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -7,6 +7,8 @@
         exp = tensor_create(TensorType, (i) -> :(f($i)))
     elseif order == 2
         exp = tensor_create(TensorType, (i,j) -> :(f($i, $j)))
+    elseif order == 3
+        exp = tensor_create(TensorType, (i,j,k) -> :(f($i, $j, $k)))
     elseif order == 4
         exp = tensor_create(TensorType, (i,j,k,l) -> :(f($i, $j, $k, $l)))
     end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -15,6 +15,13 @@ end
     return dim*(j-1) + i
 end
 
+@inline function compute_index(::Type{Tensor{3, dim}}, i::Int, j::Int, k::Int) where {dim}
+    lower_order = Tensor{2, dim}
+    I = compute_index(lower_order, i, j)
+    n = n_components(lower_order)
+    return (k-1) * n + I
+end
+
 @inline function compute_index(::Type{Tensor{4, dim}}, i::Int, j::Int, k::Int, l::Int) where {dim}
     lower_order = Tensor{2, dim}
     I = compute_index(lower_order, i, j)
@@ -62,8 +69,8 @@ end
 # Slice
 @inline Base.getindex(v::Vec, ::Colon) = v
 
-function Base.getindex(S::Union{SecondOrderTensor, FourthOrderTensor}, ::Colon)
-    throw(ArgumentError("S[:] not defined for S of order 2 or 4, use Array(S) to convert to an Array"))
+function Base.getindex(S::Union{SecondOrderTensor, Tensor{3}, FourthOrderTensor}, ::Colon)
+    throw(ArgumentError("S[:] not defined for S of order 2, 3, or 4, use Array(S) to convert to an Array"))
 end
 
 @inline @generated function Base.getindex(S::SecondOrderTensor{dim}, ::Colon, j::Int) where {dim}

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -102,40 +102,6 @@ end
     end
 end
 
-@generated function dcontract(S1::FourthOrderTensor{dim}, S2::Tensor{3,dim}) where {dim}
-    TensorType = getreturntype(dcontract, get_base(S1), get_base(S2))
-    idxS1(i, j, k, l) = compute_index(get_base(S1), i, j, k, l)
-    idxS2(i, j, k) = compute_index(get_base(S2), i, j, k)
-    exps = Expr(:tuple)
-    for k in 1:dim, j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j, m, n))]) for m in 1:dim, n in 1:dim][:]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(m, n, k))])    for m in 1:dim, n in 1:dim][:]
-        push!(exps.args, reducer(ex1, ex2, true))
-    end
-    expr = remove_duplicates(TensorType, exps)
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds return $TensorType($expr)
-    end
-end
-
-@generated function dcontract(S1::Tensor{3,dim}, S2::FourthOrderTensor{dim}) where {dim}
-    TensorType = getreturntype(dcontract, get_base(S1), get_base(S2))
-    idxS1(i, j, k) = compute_index(get_base(S1), i, j, k)
-    idxS2(i, j, k, l) = compute_index(get_base(S2), i, j, k, l)
-    exps = Expr(:tuple)
-    for l in 1:dim, k in 1:dim, j in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(j, m, n))]) for m in 1:dim, n in 1:dim][:]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(m, n, k, l))]) for m in 1:dim, n in 1:dim][:]
-        push!(exps.args, reducer(ex1, ex2, true))
-    end
-    expr = remove_duplicates(TensorType, exps)
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds return $TensorType($expr)
-    end
-end
-
 @generated function dcontract(S1::FourthOrderTensor{dim}, S2::FourthOrderTensor{dim}) where {dim}
     TensorType = getreturntype(dcontract, get_base(S1), get_base(S2))
     idxS1(i, j, k, l) = compute_index(get_base(S1), i, j, k, l)
@@ -421,45 +387,61 @@ end
     end
 end
 
-@generated function LinearAlgebra.dot(S1::Vec{dim}, S2::FourthOrderTensor{dim}) where {dim}
-    idxS2(i, j, k, l) = compute_index(get_base(S2), i, j, k, l)
-    exps = Expr(:tuple)
-    for k in 1:dim, j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$m])                   for m in 1:dim]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(m, i, j, k))]) for m in 1:dim]
-        push!(exps.args, reducer(ex1, ex2))
-    end
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds return Tensor{3, dim}($exps)
-    end
-end
-
-@generated function LinearAlgebra.dot(S1::FourthOrderTensor{dim}, S2::Vec{dim}) where {dim}
-    idxS1(i, j, k, l) = compute_index(get_base(S1), i, j, k, l)
-    exps = Expr(:tuple)
-    for k in 1:dim, j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS2(i, j, k, m))]) for m in 1:dim]
-        ex2 = Expr[:(get_data(S2)[$m])                   for m in 1:dim]
-        push!(exps.args, reducer(ex1, ex2))
-    end
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds return Tensor{3, dim}($exps)
-    end
-end
-
 @generated function LinearAlgebra.dot(S1::Tensor{3,dim}, S2::Vec{dim}) where {dim}
     idxS1(i, j, k) = compute_index(get_base(S1), i, j, k)
     exps = Expr(:tuple)
     for j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS2(i, j, m))]) for m in 1:dim]
+        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j, m))]) for m in 1:dim]
         ex2 = Expr[:(get_data(S2)[$m])                for m in 1:dim]
         push!(exps.args, reducer(ex1, ex2))
     end
     quote
         $(Expr(:meta, :inline))
         @inbounds return Tensor{2, dim}($exps)
+    end
+end
+
+@generated function LinearAlgebra.dot(S1::Vec{dim}, S2::Tensor{3,dim}) where {dim}
+    idxS2(i, j, k) = compute_index(get_base(S2), i, j, k)
+    exps = Expr(:tuple)
+    for j in 1:dim, i in 1:dim
+        ex1 = Expr[:(get_data(S1)[$m]) for m in 1:dim]
+        ex2 = Expr[:(get_data(S2)[$(idxS2(m, i, j))])                for m in 1:dim]
+        push!(exps.args, reducer(ex1, ex2))
+    end
+    quote
+        $(Expr(:meta, :inline))
+        @inbounds return Tensor{2, dim}($exps)
+    end
+end
+
+@generated function LinearAlgebra.dot(S1::SecondOrderTensor{dim}, S2::Tensor{3,dim}) where {dim}
+    idxS1(i, j) = compute_index(get_base(S1), i, j)
+    idxS2(i, j, k) = compute_index(get_base(S2), i, j, k)
+    exps = Expr(:tuple)
+    for k in 1:dim, j in 1:dim, i in 1:dim
+        ex1 = Expr[:(get_data(S1)[$(idxS1(i, m))]) for m in 1:dim]
+        ex2 = Expr[:(get_data(S2)[$(idxS2(m, j, k))]) for m in 1:dim]
+        push!(exps.args, reducer(ex1, ex2))
+    end
+    quote
+        $(Expr(:meta, :inline))
+        @inbounds return Tensor{3, dim}($exps)
+    end
+end
+
+@generated function LinearAlgebra.dot(S1::Tensor{3,dim}, S2::SecondOrderTensor{dim}) where {dim}
+    idxS1(i, j, k) = compute_index(get_base(S1), i, j, k)
+    idxS2(i, j) = compute_index(get_base(S2), i, j)
+    exps = Expr(:tuple)
+    for k in 1:dim, j in 1:dim, i in 1:dim
+        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j, m))]) for m in 1:dim]
+        ex2 = Expr[:(get_data(S2)[$(idxS2(m, k))]) for m in 1:dim]
+        push!(exps.args, reducer(ex1, ex2))
+    end
+    quote
+        $(Expr(:meta, :inline))
+        @inbounds return Tensor{3, dim}($exps)
     end
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -84,6 +84,8 @@ function dcontract end
 @pure getreturntype(::typeof(dcontract), ::Type{<:SecondOrderTensor{dim}}, ::Type{<:SymmetricTensor{4, dim}}) where {dim} = SymmetricTensor{2, dim}
 @pure getreturntype(::typeof(dcontract), ::Type{<:Tensor{3,dim}}, ::Type{<:SecondOrderTensor{dim}}) where {dim} = Vec{dim}
 @pure getreturntype(::typeof(dcontract), ::Type{<:SecondOrderTensor{dim}}, ::Type{<:Tensor{3,dim}}) where {dim} = Vec{dim}
+@pure getreturntype(::typeof(dcontract), ::Type{<:Tensor{3,dim}}, ::Type{<:FourthOrderTensor{dim}}) where {dim} = Tensor{3,dim}
+@pure getreturntype(::typeof(dcontract), ::Type{<:FourthOrderTensor{dim}}, ::Type{<:Tensor{3,dim}}) where {dim} = Tensor{3,dim}
 
 # otimes
 function otimes end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -7,6 +7,8 @@ function tensor_create(::Type{Tensor{order, dim}}, f) where {order, dim}
         ex = Expr(:tuple, [f(i) for i=1:dim]...)
     elseif order == 2
         ex = Expr(:tuple, [f(i,j) for i=1:dim, j=1:dim]...)
+    elseif order == 3
+        ex = Expr(:tuple, [f(i,j,k) for i=1:dim, j=1:dim, k=1:dim]...)
     elseif order == 4
         ex = Expr(:tuple, [f(i,j,k,l) for i=1:dim, j=1:dim, k = 1:dim, l = 1:dim]...)
     end
@@ -80,6 +82,8 @@ function dcontract end
 @pure getreturntype(::typeof(dcontract), ::Type{<:SymmetricTensor{4, dim}}, ::Type{<:SecondOrderTensor{dim}}) where {dim} = SymmetricTensor{2, dim}
 @pure getreturntype(::typeof(dcontract), ::Type{<:SecondOrderTensor{dim}}, ::Type{<:Tensor{4, dim}}) where {dim} = Tensor{2, dim}
 @pure getreturntype(::typeof(dcontract), ::Type{<:SecondOrderTensor{dim}}, ::Type{<:SymmetricTensor{4, dim}}) where {dim} = SymmetricTensor{2, dim}
+@pure getreturntype(::typeof(dcontract), ::Type{<:Tensor{3,dim}}, ::Type{<:SecondOrderTensor{dim}}) where {dim} = Vec{dim}
+@pure getreturntype(::typeof(dcontract), ::Type{<:SecondOrderTensor{dim}}, ::Type{<:Tensor{3,dim}}) where {dim} = Vec{dim}
 
 # otimes
 function otimes end

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -338,5 +338,4 @@ S(C) = S(C, μ, Kb)
     
     end
 
-    
 end # testsection

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -117,6 +117,16 @@ S(C) = S(C, μ, Kb)
                 @test ∇∇(A -> T(1), A, :all)[2] ≈ 0*A
                 @test ∇∇(A -> T(1), A, :all)[3] == T(1)
             end
+            @testsection "3rd order" begin
+                δ(i,j) = (i==j ? 1 : 0)
+                #
+                f1(x::Vec) = x⊗x 
+                df1(x::Vec{d}) where d = Tensor{3,d}((i,j,k)-> δ(i,k)*x[j] + δ(j,k)*x[i]);
+                for dim in 1:3
+                    z = rand(Vec{dim})
+                    @test gradient(f1, z) ≈ df1(z)
+                end 
+            end
             end # loop T
         end # testsection
     end # loop dim

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,9 +1,9 @@
 @testsection "constructors" begin
-for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
+for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,3,4)
     for op in (rand, zero, ones, randn)
         # Tensor, SymmetricTensor
         for TensorType in (Tensor, SymmetricTensor)
-            TensorType == SymmetricTensor && order == 1 && continue
+            TensorType == SymmetricTensor && isodd(order) && continue
             N = Tensors.n_components(TensorType{order, dim})
             t = (@inferred (op)(TensorType{order, dim}))::TensorType{order, dim, Float64}
             t = (@inferred (op)(TensorType{order, dim, T}))::TensorType{order, dim, T}
@@ -26,8 +26,8 @@ for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
         @test (@inferred Vec(t...))::Tensor{1,dim,T,dim} == Vec{dim}(t)
     end
     for TensorType in (Tensor, SymmetricTensor), (func, el) in ((zeros, zero), (ones, one))
-        TensorType == SymmetricTensor && order == 1 && continue
-        order == 1 && func == ones && continue # one not supported for Vec's
+        TensorType == SymmetricTensor && isodd(order) && continue
+        isodd(order) && func == ones && continue # one not supported for Vec's
         N = Tensors.n_components(TensorType{order, dim})
         tens_arr1 = func(TensorType{order, dim}, 1)
         tens_arr2 = func(TensorType{order, dim, T}, 2, 2)
@@ -44,14 +44,14 @@ for dim in (1, 2, 3)
           Vec{dim}(z)::Vec{dim,Float64}
     @test Vec{dim,Float32}(ntuple(z, dim))::Vec{dim,Float32} ==
           Vec{dim,Float32}(z)::Vec{dim,Float32}
-    for order in (1, 2, 4)
+    for order in (1, 2, 3, 4)
         N = Tensors.n_components(Tensor{order,dim})
         @test Tensor{order,dim}(ntuple(z, N))::Tensor{order,dim,Float64} ==
               Tensor{order,dim}(z)::Tensor{order,dim,Float64}
         @test Tensor{order,dim,Float32}(ntuple(z, N))::Tensor{order,dim,Float32} ==
               Tensor{order,dim,Float32}(z)::Tensor{order,dim,Float32}
         @test_throws MethodError Tensor{order,dim}(ntuple(z, N+1))
-        order == 1 && continue
+        isodd(order) && continue
         N = Tensors.n_components(SymmetricTensor{order,dim})
         @test SymmetricTensor{order,dim}(ntuple(z, N))::SymmetricTensor{order,dim,Float64} ==
               SymmetricTensor{order,dim}(z)::SymmetricTensor{order,dim,Float64}
@@ -140,7 +140,7 @@ end # of testset
 
 @testsection "simple math" begin
 for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Tensor, SymmetricTensor)
-    TensorType == SymmetricTensor && order == 1 && continue
+    TensorType == SymmetricTensor && isodd(order) && continue
     t = rand(TensorType{order, dim, T})
 
     # Binary tensor tensor: +, -
@@ -478,6 +478,34 @@ for T in (Float32, Float64, F64)
         @test II_sym ⊡ A_sym ≈ A_sym
         @test A_sym ⊡ II_sym ≈ A_sym
         @test II_sym ⊡ A_sym ⊡ A_sym ≈ (tr(A_sym' ⋅ A_sym))
+    end
+end
+
+for T in (Float64,)
+    for dim in 1:3
+        # Tested operations
+        # S2 ⋅ S3,  S3 ⋅ S2 
+        # S1 ⊗ S2, S2 ⊗ S1
+        # S3 ⊡ S2, S2 ⊡ S3
+        
+        # Identities involving 3rd order tensors 
+        I2 = one(Tensor{2,dim,T})
+        A2 = rand(Tensor{2,dim,T})
+        S2 = rand(Tensor{2,dim,T})
+        S2s = rand(SymmetricTensor{2,dim,T})
+        S2sr = Tensor{2,dim,T}(S2s)
+        v = rand(Vec{dim,T})
+        u = rand(Vec{dim,T})
+        @test (u⊗I2)⋅v ≈ (u⊗v)
+        @test u⋅(I2⊗v) ≈ (u⊗v)
+        @test I2⋅(v⊗S2) ≈ (v⊗S2)
+        @test v ⊗ (S2⋅A2) ≈ (v ⊗ S2)⋅A2
+        @test v ⊗ S2s ≈ v ⊗ S2sr
+        @test S2s ⊗ v ≈ S2sr ⊗ v
+        @test (v⊗S2)⊡A2 ≈ v*(S2⊡A2)
+        @test (v⊗S2)⊡S2s ≈ v*(S2⊡S2s)
+        @test A2⊡(S2⊗v) ≈ v*(S2⊡A2)
+        @test S2s⊡(S2⊗v) ≈ v*(S2⊡S2s)
     end
 end
 end # of testset

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -10,6 +10,8 @@ for T in (Float32, Float64, F64), dim in (1,2,3)
 println("T = $T, dim = $dim")
 AA = rand(Tensor{4, dim, T})
 BB = rand(Tensor{4, dim, T})
+A3 = rand(Tensor{3, dim, T})
+B3 = rand(Tensor{3, dim, T})
 A = rand(Tensor{2, dim, T})
 B = rand(Tensor{2, dim, T})
 a = rand(Tensor{1, dim, T})
@@ -32,6 +34,10 @@ i,j,k,l = rand(1:dim,4)
     @test vec((@inferred dcontract(AA_sym, BB_sym))::SymmetricTensor{4, dim, T}) ≈ vec(collect(reshape(vec(AA_sym), (dim^2, dim^2))) * collect(reshape(vec(BB_sym), (dim^2, dim^2))))
     @test dcontract(convert(Tensor, AA_sym), convert(Tensor, BB_sym))            ≈ dcontract(AA_sym, BB_sym)
 
+    # 3 - 4
+    @test dcontract(AA, A3) ≈ Tensor{3,dim}((i,j,k) -> sum(AA[i,j,m,n]*A3[m,n,k] for m in 1:dim, n in 1:dim))
+    @test dcontract(A3, AA) ≈ Tensor{3,dim}((i,j,k) -> sum(A3[i,m,n]*AA[m,n,j,k] for m in 1:dim, n in 1:dim))
+
     # 2 - 4
     @test (@inferred dcontract(AA, A))::Tensor{2, dim, T}                  ≈ reshape(collect(reshape(vec(AA), (dim^2, dim^2))) * collect(reshape(vec(A), (dim^2,))), dim, dim)
     @test (@inferred dcontract(AA_sym, A))::SymmetricTensor{2, dim, T}     ≈ reshape(collect(reshape(vec(AA_sym), (dim^2, dim^2))) * collect(reshape(vec(A), (dim^2,))), dim, dim)
@@ -42,6 +48,10 @@ i,j,k,l = rand(1:dim,4)
     @test (@inferred dcontract(A, AA_sym))::SymmetricTensor{2, dim, T}     ≈ reshape(collect(reshape(vec(AA_sym), (dim^2, dim^2))') * collect(reshape(vec(A), (dim^2,))), dim, dim)
     @test (@inferred dcontract(A_sym, AA_sym))::SymmetricTensor{2, dim, T} ≈ reshape(collect(reshape(vec(AA_sym), (dim^2, dim^2))') * collect(reshape(vec(A_sym), (dim^2,))), dim, dim)
     @test dcontract(convert(Tensor, AA_sym), convert(Tensor, A_sym))       ≈ dcontract(AA_sym, A_sym)
+
+    # 2 - 3
+    @test dcontract(A, A3) ≈ Tensor{1,dim}((i) -> sum(A[m,n]*A3[m,n,i] for m in 1:dim, n in 1:dim))
+    @test dcontract(A3, A) ≈ Tensor{1,dim}((i) -> sum(A3[i,m,n]*A[m,n] for m in 1:dim, n in 1:dim))
 
     # 2 - 2
     @test (@inferred dcontract(A, B))::T         ≈ sum(vec(A) .* vec(B))

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -7,6 +7,7 @@ end
 
 @testsection "tensor ops" begin
 for T in (Float32, Float64, F64), dim in (1,2,3)
+println("T = $T, dim = $dim")
 AA = rand(Tensor{4, dim, T})
 BB = rand(Tensor{4, dim, T})
 A = rand(Tensor{2, dim, T})

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -7,7 +7,6 @@ end
 
 @testsection "tensor ops" begin
 for T in (Float32, Float64, F64), dim in (1,2,3)
-println("T = $T, dim = $dim")
 AA = rand(Tensor{4, dim, T})
 BB = rand(Tensor{4, dim, T})
 A = rand(Tensor{2, dim, T})


### PR DESCRIPTION
Start of limited support for 3rd order tensors.
Currently, the aim is just to implement what is required for mapping of Hcurl and Hdiv interpolations in Ferrite (Co- and Contra-variant Piola mapping)