### PR TITLE
Bugfix: tovoigt for different eltype of tensor and vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.16.1]
+
+### Bugfixes
+
+ - Fix that `tovoigt!(::Vector{TA}, ::AbstractTensor{order,dim,TB})` didn't work after v1.15 unless `TA==TB`
+
 ## [1.16.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
- - Fix that `tovoigt!(::Vector{TA}, ::AbstractTensor{order,dim,TB})` didn't work after v1.15 unless `TA==TB`
+ - Fix that `tovoigt!(::Vector{TA}, ::AbstractTensor{order,dim,TB})` didn't work after v1.15 unless `TA==TB` [#212][github-212]
 
 ## [1.16.0]
 
@@ -29,4 +29,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.15.1]: https://github.com/Ferrite-FEM/Tensors.jl/compare/v1.15.0...v1.15.1
 
 <!-- GitHub pull request/issue links -->
+[github-212]: https://github.com/Ferrite-FEM/Tensors.jl/pull/212
 [github-205]: https://github.com/Ferrite-FEM/Tensors.jl/pull/205

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensors"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.16.0"
+version = "1.16.1"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -138,14 +138,14 @@ Base.@propagate_inbounds function tovoigt!(v::AbstractMatrix{T}, A::SymmetricTen
 end
 
 # default voigt order (faster than custom voigt order)
-Base.@propagate_inbounds function _tovoigt!(v::AbstractVecOrMat{T}, A::SecondOrderTensor{dim,T}, ::Nothing; offset=0, offdiagscale=one(T)) where {dim,T}
+Base.@propagate_inbounds function _tovoigt!(v::AbstractVecOrMat{T}, A::SecondOrderTensor{dim}, ::Nothing; offset=0, offdiagscale=one(T)) where {dim,T}
     tuple_data, = _to_voigt_tuple(A, offdiagscale)
     for i in eachindex(tuple_data)
         v[offset+i] = tuple_data[i]
     end
     return v
 end
-Base.@propagate_inbounds function _tovoigt!(v::AbstractVecOrMat{T}, A::SymmetricTensor{4,dim,T}, ::Nothing; offdiagscale=one(T), offset_i=0, offset_j=0) where {dim,T}
+Base.@propagate_inbounds function _tovoigt!(v::AbstractVecOrMat{T}, A::SymmetricTensor{4,dim}, ::Nothing; offdiagscale=one(T), offset_i=0, offset_j=0) where {dim,T}
     tuple_data, N = _to_voigt_tuple(A, offdiagscale)
     cartesian = CartesianIndices(((offset_i+1):(offset_i+N), (offset_j+1):(offset_j+N)))
     for i in eachindex(tuple_data)
@@ -154,7 +154,7 @@ Base.@propagate_inbounds function _tovoigt!(v::AbstractVecOrMat{T}, A::Symmetric
     return v
 end
 
-Base.@propagate_inbounds function _tovoigt!(v::AbstractVecOrMat{T}, A::Tensor{4,dim,T}, ::Nothing; kwargs...) where {dim,T}
+Base.@propagate_inbounds function _tovoigt!(v::AbstractVecOrMat{T}, A::Tensor{4,dim}, ::Nothing; kwargs...) where {dim,T}
     return _tovoigt!(v, A, DEFAULT_VOIGT_ORDER[dim]; kwargs...)
 end
 

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -327,9 +327,16 @@ end
     @test (@inferred frommandel(Tensor{4,dim}, tomandel(AA))) ≈ AA
 
     if T==Float64
+        # Check that Boolean values are supported for fromvoigt
         num_components = Int((dim^2+dim)/2)
         @test isa(fromvoigt(SymmetricTensor{2,dim}, rand(num_components) .> 0.5), SymmetricTensor{2,dim,Bool})
         @test isa(fromvoigt(SymmetricTensor{4,dim}, rand(num_components,num_components) .> 0.5), SymmetricTensor{4,dim,Bool})
+        
+        # Check that different types in the vector and tensor is supported via conversion
+        @test tovoigt!(zeros(Float32, nc(A)), A)::Vector{Float32} ≈ tovoigt(A)
+        @test tovoigt!(zeros(Float32, nc(A_sym)), A_sym)::Vector{Float32} ≈ tovoigt(A_sym)
+        @test tovoigt!(zeros(Float32, nc(AA), nc(AA)), AA)::Matrix{Float32} ≈ tovoigt(AA)
+        @test tovoigt!(zeros(Float32, nc(AA_sym), nc(AA_sym)), AA_sym)::Matrix{Float32} ≈ tovoigt(AA_sym)
     end
 
     # Static voigt/mandel that use default order


### PR DESCRIPTION
This broke my code that used to work, where I was doing automatic differentiation but not all tensor elements I wanted to put in my vector were dual numbers.