### PR TITLE
Hook into Random API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,17 +5,18 @@ version = "1.16.1"
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ForwardDiff = "0.10"
-SIMD = "2, 3"
-PrecompileTools = "1"
-StaticArrays = "1"
 LinearAlgebra = "1"
+PrecompileTools = "1"
+SIMD = "2, 3"
+StaticArrays = "1"
 Statistics = "1"
 julia = "1"
 

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -2,7 +2,7 @@ module Tensors
 
 import Base.@pure
 
-import Statistics
+import Statistics, Random
 using Statistics: mean
 using LinearAlgebra
 using StaticArrays

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -19,6 +19,17 @@ for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,3,4)
             (@inferred (op)(Vec{dim, T}))::Tensor{order, dim, T}
         end
     end
+    # Random numbers with samplers 
+    for TensorType in (Tensor, SymmetricTensor)
+        TensorType == SymmetricTensor && isodd(order) && continue
+        TT = TensorType{order, dim, T}
+        @test rand(MersenneTwister(1), TT) ≈ rand(MersenneTwister(1), TT)       # Check that rng was actually used
+        @test rand(MersenneTwister(2), TT) ≈ rand(MersenneTwister(2), rand(TT)) # Check same value when given a value
+        @inferred Vector{<:TT} rand(TT, 2) # Construct a Vector of random tensors
+        if order == 1
+            @test rand(MersenneTwister(1), Vec{dim}) ≈ rand(MersenneTwister(1), TT)
+        end
+    end
     # Special Vec constructor
     if order == 1
         t = ntuple(i -> T(i), dim)


### PR DESCRIPTION
Following [Hooking into the Random API](https://docs.julialang.org/en/v1/stdlib/Random/#Hooking-into-the-Random-API) I replaced the `Base.rand(Type{<:AbstractTensor})` by `Base.rand(rng::AbstractRNG, ::SamplerType{<:AbstractTensor})`, which has the advantage of supporting

* Using a different generators, e.g. `rand(MersenneTwister(1), Tensor{2,3})`
* Support creating an array of random tensors by e.g. `rand(Vec{2}, 2)`
* Combinations thereof, e.g. `rand(MersenneTwister(2), Vec{2}, 2)`

AFAIU the same API doesn't work for `randn`, so this is kept as is. 