### PR TITLE
Fix curl calling 3d function for 1d and 2d vectors

### DIFF
--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -578,8 +578,17 @@ function curl(f::F, v::Vec{3}) where F
     end
     return c
 end
-curl(f::F, v::Vec{1, T}) where {F, T} = curl(f, Vec{3}((v[1], T(0), T(0))))
-curl(f::F, v::Vec{2, T}) where {F, T} = curl(f, Vec{3}((v[1], v[2], T(0))))
+function curl(f::F, v::Vec{2, T}) where {F, T}
+    @inbounds begin
+        ∇f = gradient(f, v)
+        c = Vec{3}((zero(T), zero(T), ∇f[2,1] - ∇f[1,2]))
+    end
+    return c
+end
+function curl(f::F, v::Vec{1, T}) where {F, T}
+    TR = promote_type(T, eltype(f(v)))
+    return zero(Vec{3,  TR})
+end
 
 """
     laplace(f, x)


### PR DESCRIPTION
Noticed that 
```julia
curl(x -> rotate(x, angle::Real), rand(Vec{2}))
```
failed since `rotate(::Vec{3}, angle::Real)` is not defined.
The new implementation should be faster as well, but haven't benchmarked. 