### PR TITLE
Throw error if trying to call fallback dot method for AbstractArray

### DIFF
--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -306,6 +306,14 @@ julia> otimesl(A, B)
     return Tensor{4, dim}((i,j,k,l) -> S1_[i,l] * S2_[j,k])
 end
 
+# Ensure that we don't fall back to the default implementation for AbstractArray, 
+# which has a different meaning except in the case for `Vec`. 
+function LinearAlgebra.dot(ta::AbstractTensor, tb::AbstractTensor)
+    TA = get_base(typeof(ta))
+    TB = get_base(typeof(tb))
+    throw(ArgumentError("single contraction not implemented between $TA and $TB"))
+end
+
 """
     dot(::Vec, ::Vec)
     dot(::Vec, ::SecondOrderTensor)

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -669,4 +669,8 @@ end
     @test_throws ArgumentError x'
     @test_throws ArgumentError transpose(x)
     @test_throws ArgumentError adjoint(x)
+
+    # Non-implemented single contractions
+    t10 = Tensor{10, 1, Float64, 10}(tuple((1.0 for _ in 1:10)...));
+    @test_throws ArgumentError (t10 ⋅ t10)
 end # of testset


### PR DESCRIPTION
Partially addresses #227 by at least throwing error.

Of course this could/should be implemented, but would be nice to do after #211.