### PR TITLE
Add infix for otimesu and otimesl

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -14,7 +14,7 @@ export mean
 export AbstractTensor, SymmetricTensor, Tensor, Vec, FourthOrderTensor, SecondOrderTensor
 
 export otimes, ⊗, ⊡, dcontract, dev, vol, symmetric, skew, minorsymmetric, majorsymmetric
-export otimesu, otimesl
+export otimesu, ⊗̅, otimesl, ⊗̲
 export minortranspose, majortranspose, isminorsymmetric, ismajorsymmetric
 export tdot, dott, dotdot
 export hessian, gradient, curl, divergence, laplace

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -237,7 +237,8 @@ end
 """
     otimesu(::SecondOrderTensor, ::SecondOrderTensor)
 
-Compute the "upper" open product between two tensors.
+Compute the "upper" open product between two tensors, ``C_{ijkl} = A_{ik} B_{jl}``.
+The symbol `⊗̅`, written `\\otimes\\overbar`, is overloaded for the upper tensor product.
 
 # Examples
 ```jldoctest
@@ -245,7 +246,7 @@ julia> A = rand(SymmetricTensor{2, 2});
 
 julia> B = rand(SymmetricTensor{2, 2});
 
-julia> otimesu(A, B)
+julia> A ⊗̅ B # Alternatively otimesu(A, B)
 2×2×2×2 Tensor{4, 2, Float64, 16}:
 [:, :, 1, 1] =
  0.291503  0.115106
@@ -270,10 +271,13 @@ julia> otimesu(A, B)
     return Tensor{4, dim}((i,j,k,l) -> S1_[i,k] * S2_[j,l])
 end
 
+const ⊗̅ = otimesu
+
 """
     otimesl(::SecondOrderTensor, ::SecondOrderTensor)
 
-Compute the "lower" open product between two tensors.
+Compute the "lower" open product between two tensors, ``C_{ijkl} = A_{il} B_{jk}``.
+The symbol `⊗̲`, written `\\otimes\\underbar`, is overloaded for the lower tensor product.
 
 # Examples
 ```jldoctest
@@ -281,7 +285,7 @@ julia> A = rand(SymmetricTensor{2, 2});
 
 julia> B = rand(SymmetricTensor{2, 2});
 
-julia> otimesl(A, B)
+julia> A ⊗̲ B # Alternatively otimesl(A, B)
 2×2×2×2 Tensor{4, 2, Float64, 16}:
 [:, :, 1, 1] =
  0.291503  0.115106
@@ -305,6 +309,8 @@ julia> otimesl(A, B)
     S2_ = convert(Tensor, S2)
     return Tensor{4, dim}((i,j,k,l) -> S1_[i,l] * S2_[j,k])
 end
+
+const ⊗̲ = otimesl
 
 """
     dot(::Vec, ::Vec)

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -81,6 +81,14 @@ end # of testsection
     @test (@inferred otimesl(A_sym, B))::Tensor{4, dim, T}     ≈ _permutedims(otimes(A_sym, B), (1,3,4,2))
     @test (@inferred otimesl(A, B_sym))::Tensor{4, dim, T}     ≈ _permutedims(otimes(A, B_sym), (1,3,4,2))
     @test (@inferred otimesl(A_sym, B_sym))::Tensor{4, dim, T} ≈ _permutedims(otimes(A_sym, B_sym), (1,3,4,2))
+
+    # Infix operators
+    @test (@inferred (A ⊗̅ B)) ≈ otimesu(A, B)
+    @test (@inferred (A ⊗̲ B)) ≈ otimesl(A, B)
+    # As extra safeguard, we test the operator precedence directly,
+    @test all(k -> Base.operator_precedence(k) == Base.operator_precedence(:*), (:⊗, :⊗̅, :⊗̲))
+    @test A ⊗̅ B + 2A ⊗ B ≈ otimesu(A, B) + otimes(2A, B)
+    @test A ⊗̲ B + 2A ⊗ B ≈ otimesl(A, B) + otimes(2A, B)
 end # of testsection
 
 @testsection "dot products" begin


### PR DESCRIPTION
Support `A ⊗̅ B` and `A ⊗̲ B` for `otimesu` and `otimesl`

